### PR TITLE
Fixes AlphonsoCode/DEF#2618. Bugfix race condition for active host state

### DIFF
--- a/lib/webhdfs.js
+++ b/lib/webhdfs.js
@@ -57,6 +57,23 @@ function WebHDFS (opts, requestParams) {
 }
 
 /**
+ *  Switch to the next suitable host for retrying.
+ *
+ *  The switch happens if the reported index of host array by caller is same as the current index,
+ *  otherwise the caller is uses the same index.
+ *
+ *  @method _switchHost
+ *
+ *  @param {Int} Current host index as reported by the caller
+ */
+WebHDFS.prototype._switchHost = function(idx) {
+    if( this._curr_host_idx == idx )
+        this._curr_host_idx = !this._curr_host_idx + 0; // move to next index
+
+    this._url.hostname    = this._opts.host[this._curr_host_idx];
+}
+
+/**
  * Generate WebHDFS REST API endpoint URL for given operation
  *
  * @method _getOperationEndpoint
@@ -175,6 +192,8 @@ WebHDFS.prototype._sendRequest = function _sendRequest (method, url, opts, callb
   var self      = this;
   var params    = extend({ method: method, url: url, json: true }, this._requestParams, opts);
   var req       = request(params, onComplete);
+  // Remember for switchHost
+  req._requested_host_idx = self._curr_host_idx;
 
   function onComplete(err, res, body)
   {
@@ -194,8 +213,7 @@ WebHDFS.prototype._sendRequest = function _sendRequest (method, url, opts, callb
       {
         if(!opts._retry)
         {
-          self._curr_host_idx   = !self._curr_host_idx + 0;
-          self._url.hostname    = self._opts.host[self._curr_host_idx];
+          self._switchHost(req._requested_host_idx);
           var urlJSON           = $url.parse(url);
           urlJSON.hostname      = self._url.hostname;
           delete urlJSON.host;
@@ -640,6 +658,9 @@ WebHDFS.prototype.createWriteStream = function createWriteStream (path, append, 
     }
   });
 
+  // remember for the switchHost
+  req._requested_host_idx = self._curr_host_idx;
+
   req.on('pipe', function onPipe (src) {
     // Pause read stream
     stream = src;
@@ -664,8 +685,7 @@ WebHDFS.prototype.createWriteStream = function createWriteStream (path, append, 
 };
 
 function _doWriteStreamRetry(self, _req, params, append, path, opts, stream){
-    self._curr_host_idx = !self._curr_host_idx + 0;
-    self._url.hostname  = self._opts.host[self._curr_host_idx];
+    self._switchHost(_req._requested_host_idx);
     params.url          = self._getOperationEndpoint(append ? 'append' : 'create', path, extend({
                               overwrite: true,
                               permissions: '0777'
@@ -793,6 +813,8 @@ WebHDFS.prototype.createReadStream = function createReadStream (path, opts) {
   }, this._requestParams);
 
   var req = request(params);
+  // remember for switchHost
+  req._requested_host_idx = self._curr_host_idx;
 
   req.on('end', function(){
     // check if to ignore the first `end` event emitted before retrying in case of failover switch
@@ -803,9 +825,11 @@ WebHDFS.prototype.createReadStream = function createReadStream (path, opts) {
   req.on('error', function(error){
     if(self._opts.host.length > 1 && error.code === 'ECONNREFUSED') // retry iff namenode daemon is down
     {
-      self._curr_host_idx = !self._curr_host_idx + 0;
-      self._url.hostname  = self._opts.host[self._curr_host_idx];
+      self._switchHost(req._requested_host_idx);
       params.url          = self._getOperationEndpoint('open', path, opts);
+      // remember for the next time, if needed. FIXME: May not be needed again at all as
+      // we are making a last retry here.
+      req._requested_host_idx = self._curr_host_idx;
       req.retrying = true;
       console.log('[webhdfs]: Retrying with url: '+ params.url);
       _doRetry(self, req, params);
@@ -827,9 +851,11 @@ WebHDFS.prototype.createReadStream = function createReadStream (path, opts) {
           }
           else
           {
-            self._curr_host_idx = !self._curr_host_idx + 0;
-            self._url.hostname  = self._opts.host[self._curr_host_idx];
+            self._switchHost(req._requested_host_idx);
             params.url          = self._getOperationEndpoint('open', path, opts);
+            // remember for the next time, if needed. FIXME: May not be needed again at all as
+            // we are making a last retry here.
+            req._requested_host_idx = self._curr_host_idx;
             req.retrying = true;
             console.log('[webhdfs]: Retrying with url: '+ params.url);
             _doRetry(self, req, params);


### PR DESCRIPTION
Since, the current active namenode state is shared across webhdfs object.
So in a scenario where two almost parallel requests are made towards a same
stanby namenode, one of the requests would trigger a switchover in the
state and the other request "unaware" of the previous trigger made almost
at the same time would trigger again essentially making its request
go to the original standby namenode. The "almost same time" here means
async requests made without waiting for each others' callback and
updating the shared state as and when the callbacks are fired.

This commit fixes this bug by adding a check to distinguish between
state "seen" at the time of making the first request and the "current"
state before making a retry request. A switchover is triggered when the
two state match otherwise current state is used.